### PR TITLE
Update rules.py with `scnv.io`

### DIFF
--- a/PyFunceble/checker/availability/extras/rules.py
+++ b/PyFunceble/checker/availability/extras/rules.py
@@ -94,6 +94,7 @@ class ExtraRulesHandler(ExtraRuleHandlerBase):
             r"\.imgur\.com$": [self.handle_imgur_dot_com],
             r"\.liveadvert\.com$": [(self.switch_to_down_if_status_code, 404)],
             r"\.myhuaweicloudz\.com$": [(self.switch_to_down_if_status_code, 403)],
+            r"^scnv\.io$": [(self.switch_to_down_if_status_code, 404)],
             r"\.skyrock\.com$": [(self.switch_to_down_if_status_code, 404)],
             r"\.sz.id$": [(self.switch_to_down_if_status_code, 302)],
             r"\.translate\.goog$": [(self.switch_to_down_if_status_code, 403)],


### PR DESCRIPTION
This fix is for https://github.com/Phishing-Database/Phishing.Database/issues/971

Whitelisting this in general would be wrong. Is is a better and safer approach.

```
curl -ILs http://scnv.io/S4z2
HTTP/1.1 308 Permanent Redirect
Connection: close
Location: https://scnv.io/S4z2
Server: Caddy
Date: Thu, 26 Dec 2024 10:41:03 GMT

HTTP/2 404 
alt-svc: h3=":443"; ma=2592000
content-language: en
content-security-policy-report-only: img-src 'self' data: https://* *.amazonaws.com; font-src 'self' data: https://fonts.gstatic.com *.bootstrapcdn.com *.amazonaws.com *.flaticon.com; style-src-elem 'self' 'unsafe-inline' *.googleapis.com qcg-media.s3.amazonaws.com qcg-media.s3.us-west-2.amazonaws.com *.diageohorizon.com *.diageoagegate.com *.googletagmanager.com *.bootstrapcdn.com *.amazonaws.com *.flaticon.com; frame-ancestors 'none'; form-action 'self'; connect-src 'self' *.google.com *.amazonaws.com *.cloudfare.com; default-src 'self' *.amazonaws.com; frame-src 'self' *.youtube.com *.amazonaws.com; style-src 'self' 'unsafe-inline' *.googleapis.com *.amazonaws.com; base-uri 'self'; media-src 'self' *.amazonaws.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.cloudflare.com static.cloudflareinsights.com qcg-media.s3.us-west-2.amazonaws.com qcg-media.s3.amazonaws.com *.diageohorizon.com *.diageoagegate.com *.googletagmanager.com *.youtube.com *.bootstrapcdn.com *.amazonaws.com; report-uri https://scanova.uriports.com/reports/report/
content-type: text/html; charset=utf-8
cross-origin-opener-policy: same-origin
date: Thu, 26 Dec 2024 10:41:04 GMT
referrer-policy: strict-origin
referrer-policy: same-origin
report-to: {"group":"default","max_age":86400,"endpoints":[{"url":"https://scanova.report-uri.com/a/d/g"}],"include_subdomains":true}
server: Caddy
strict-transport-security: max-age=31536000;includeSubdomains
vary: Accept-Language
x-content-type-options: nosniff
x-frame-options: DENY
x-frame-options: DENY
x-xss-protection: 1; mode=block
content-length: 1650
```

```
curl -ILs https://scnv.io/QH2v
HTTP/2 404 
alt-svc: h3=":443"; ma=2592000
content-language: en
content-security-policy-report-only: form-action 'self'; style-src 'self' 'unsafe-inline' *.googleapis.com *.amazonaws.com; frame-src 'self' *.youtube.com *.amazonaws.com; frame-ancestors 'none'; base-uri 'self'; font-src 'self' data: https://fonts.gstatic.com *.bootstrapcdn.com *.amazonaws.com *.flaticon.com; connect-src 'self' *.google.com *.amazonaws.com *.cloudfare.com; img-src 'self' data: https://* *.amazonaws.com; style-src-elem 'self' 'unsafe-inline' *.googleapis.com qcg-media.s3.amazonaws.com qcg-media.s3.us-west-2.amazonaws.com *.diageohorizon.com *.diageoagegate.com *.googletagmanager.com *.bootstrapcdn.com *.amazonaws.com *.flaticon.com; media-src 'self' *.amazonaws.com; default-src 'self' *.amazonaws.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.cloudflare.com static.cloudflareinsights.com qcg-media.s3.us-west-2.amazonaws.com qcg-media.s3.amazonaws.com *.diageohorizon.com *.diageoagegate.com *.googletagmanager.com *.youtube.com *.bootstrapcdn.com *.amazonaws.com; report-uri https://scanova.uriports.com/reports/report/
content-type: text/html; charset=utf-8
cross-origin-opener-policy: same-origin
date: Thu, 26 Dec 2024 10:41:50 GMT
referrer-policy: strict-origin
referrer-policy: same-origin
report-to: {"group":"default","max_age":86400,"endpoints":[{"url":"https://scanova.report-uri.com/a/d/g"}],"include_subdomains":true}
server: Caddy
strict-transport-security: max-age=31536000;includeSubdomains
vary: Accept-Language
x-content-type-options: nosniff
x-frame-options: DENY
x-frame-options: DENY
x-xss-protection: 1; mode=block
content-length: 1650
```